### PR TITLE
Add additional information and events emitted by the server

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,12 @@ To install you need to either download a release, or build the mod yourself.
 
 1. [SynthRiders](https://synthridersvr.com/)
 2. [MelonLoader](https://melonwiki.xyz/#/)
-3. [SynthRiders Websocket Integration](https://github.com/KK964/SynthRiders-Websockets-Mod/releases)
 
 ### Download
 
 1. Download the latest release from [GitHub](https://github.com/KK964/SynthRiders-Websockets-Mod/releases)
 2. Extract the zip file
-3. Copy the dlls to your SynthRiders MelonLoader Mods folder
+3. Copy the dlls to your SynthRiders MelonLoader Mods folder (typically a folder called `Mods` in your SynthRiders installation.  If you see a text file named "PLACE MODS HERE.txt", you're in the right place.)
 
 ### Build
 
@@ -38,21 +37,76 @@ To install you need to either download a release, or build the mod yourself.
 
 ## Usage
 
-Connect to the websocket server; the server will send updates about the game.
+Connect to the websocket server; the server will send updates about the game.  By default, the websocket host will run at `ws://localhost:9000`.  Host and Port can be configured in the MelonPreferences.cfg file if an alternate config is required (e.g. for 2 PC stream setups)
 
 ## Events
 
-- SongStart:
-  - `SongStart {"song":"Song Name", "difficulty": "Difficulty", "author": "Author", "length": Length}`
-- SongEnd:
-  - `SongEnd {"song":"Song Name", "perfect": Perfect, "normal": Normal, "bad": Bad, "fail": Fail, "highestCombo": HighestCombo}`
-- NoteHit:
-  - `NoteHit {"combo": Combo, "completed": Completed}`
-- NoteMiss:
-  - `NoteMiss {}`
-- EnterSpecial:
-  - `EnterSpecial {}`
-- CompleteSpecial:
-  - `CompleteSpecial {}`
-- FailSpecial:
-  - `FailSpecial {}`
+All events are JSON and follow this general structure:
+
+```json
+{ "eventType": "EventType", "data": {}}
+```
+
+### SongStart 
+
+Emitted when the map begins playing.
+
+```json
+{"eventType":"SongStart","data":{"song":"2 Phut Hon (Kaiz Remix)","difficulty":"Master","author":"Phao","beatMapper":"ICHDerHorst","length":191.857,"bpm":128.0}}
+```
+
+### SongEnd
+
+Emitted as the last note of the map is completed.
+
+```json
+{"eventType":"SongEnd","data":{"song":"2 Phut Hon (Kaiz Remix)","perfect":350,"normal":126,"bad":281,"fail":2,"highestCombo":482}}
+```
+
+### PlayTime
+
+Emitted once per second when the song is playing.
+
+```json
+{"eventType":"PlayTime","data":{"playTimeMS":19662.48}}
+```
+
+- `playTimeMS` - Current play time position, in milliseconds.
+
+### NoteHit
+
+Emitted on every note hit successfully
+
+```json
+{"eventType":"NoteHit","data":{"score":938,"combo":1,"multiplier":1,"completed":1.0,"lifeBarPercent":1.0}}
+```
+
+  - `score` - Total score after the note is hit
+  - `combo` - Number of consecutive hits made so far.  This resets after a note miss.
+  - `multiplier` - Current score multiplier.  Runs from 1 to 6.
+  - `completed` - Indicates the percentage of notes completed in the map.? (CHECK THIS)
+  - `lifeBarPercent` - A number between 0 and 1 indicating life bar percentage.
+
+### NoteMiss
+
+```json
+{"eventType":"NoteMiss","data":{"multiplier":2,"lifeBarPercent":0.8333333}}
+```
+
+### EnterSpecial
+
+```json
+{"eventType":"EnterSpecial","data":{}}
+```
+
+### CompleteSpecial
+
+```json
+{"eventType":"CompleteSpecial","data":{}}
+```
+
+### FailSpecial
+
+```json
+{"eventType":"FailSpecial","data":{}}
+```

--- a/src/WebsocketMod.cs
+++ b/src/WebsocketMod.cs
@@ -259,8 +259,6 @@ namespace SynthRidersWebsockets
             OutputEvent outputEvent = new OutputEvent(eventName, data);
 
             Websocket.Send(JsonConvert.SerializeObject(outputEvent));
-
-            MelonLogger.Msg(JsonConvert.SerializeObject(outputEvent));
         }
 
         public class Websocket

--- a/src/WebsocketMod.cs
+++ b/src/WebsocketMod.cs
@@ -207,15 +207,12 @@ namespace SynthRidersWebsockets
         }
         class StageNoteMissEvent
         {
-            public float playTimeMS;
-
             public int multiplier;
 
             public float lifeBarPercent;
 
-            public StageNoteMissEvent(float playTimeMS, int multiplier, float lifeBarPercent)
+            public StageNoteMissEvent(int multiplier, float lifeBarPercent)
             {
-                this.playTimeMS = playTimeMS;
                 this.multiplier = multiplier;
                 this.lifeBarPercent = lifeBarPercent;
             }
@@ -223,7 +220,6 @@ namespace SynthRidersWebsockets
         private void OnNoteFail()
         {
             StageNoteMissEvent missEvent = new StageNoteMissEvent(
-                GameControlManager.s_instance.PlayTimeMS, 
                 GameControlManager.s_instance.ScoreManager.TotalMultiplier,
                 LifeBarHelper.GetScalePercent()
             );
@@ -233,17 +229,17 @@ namespace SynthRidersWebsockets
 
         private void OnEnterSpecial()
         {
-            Send("EnterSpecial", "{}");
+            Send("EnterSpecial", new object());
         }
 
         private void OnCompleteSpecial()
         {
-            Send("CompleteSpecial", "{}");
+            Send("CompleteSpecial", new object());
         }
 
         private void OnFailSpecial()
         {
-            Send("FailSpecial", "{}");
+            Send("FailSpecial", new object());
         }
 
         class OutputEvent

--- a/src/WebsocketMod.cs
+++ b/src/WebsocketMod.cs
@@ -17,7 +17,14 @@ using UnityEngine.Events;
 using MelonLoader;
 
 using SynthRidersWebsockets.Harmony;
-
+/*
+ * Todo:
+ * - Emit event if song failed.
+ * - Emit event is song is quit.
+ * - Previous high score
+ * - Emit what hand note was for (left, right, special one-hand, special two-hand
+ * - Score on specific hits
+ */
 namespace SynthRidersWebsockets
 {
     public class WebsocketMod : MelonMod
@@ -26,6 +33,12 @@ namespace SynthRidersWebsockets
         private static GameControlManager gameControlManager;
 
         public static MelonPreferences_Category connectionCategory;
+
+        /**
+         * Keep track of last time play time was emitted so we only emit once per second.
+         */
+        private float lastPlayTimeMS = 0;
+
         public override void OnApplicationStart() {
             Instance = this;
             connectionCategory = MelonPreferences.CreateCategory("Connection");
@@ -33,12 +46,38 @@ namespace SynthRidersWebsockets
             int port = connectionCategory.CreateEntry<int>("Port", 9000).Value;
             RuntimePatch.PatchAll();
             Websocket.Start($"{host}:{port}");
-            LoggerInstance.Msg("[Websocket] Started Mod");
+            LoggerInstance.Msg("[Websocket] Started Weboscket mod on " + host + ":" + port.ToString());
         }
         
         public override void OnApplicationQuit()
         {
             Websocket.Stop();
+        }
+
+        class PlayTimeEvent
+        {
+            public float playTimeMS;
+
+            public PlayTimeEvent(float playTimeMS)
+            {
+                this.playTimeMS = playTimeMS;
+            }
+        }
+        public override void OnUpdate()
+        {
+            // If song is playing, check the last play time.  If it's advanced at least one second, emit an update.
+            if (gameControlManager != null && gameControlManager == GameControlManager.s_instance)
+            {
+                if (gameControlManager.SongIsPlaying && (gameControlManager.PlayTimeMS - this.lastPlayTimeMS > 999))
+                {
+                    PlayTimeEvent playTimeEvent = new PlayTimeEvent(gameControlManager.PlayTimeMS);
+                    Send("PlayTime", playTimeEvent);
+                    this.lastPlayTimeMS = gameControlManager.PlayTimeMS;
+                } else if (!gameControlManager.SongIsPlaying && this.lastPlayTimeMS > 0)
+                {
+                    this.lastPlayTimeMS = 0;
+                }
+            }
         }
 
         public void GameManagerInit()
@@ -76,13 +115,18 @@ namespace SynthRidersWebsockets
             public string song;
             public string difficulty;
             public string author;
+            public string beatMapper;
             public float length;
-            public StageSongStartEvent(string song, string difficulty, string author, float length)
+            public float bpm;
+
+            public StageSongStartEvent(string song, string difficulty, string author, string beatMapper, float length, float bpm)
             {
                 this.song = song;
                 this.difficulty = difficulty;
                 this.author = author;
+                this.beatMapper = beatMapper;
                 this.length = length;
+                this.bpm = bpm;
             }
         }
         private void OnSongStart()
@@ -91,9 +135,12 @@ namespace SynthRidersWebsockets
                 GameControlManager.s_instance.InfoProvider.TrackName,
                 GameControlManager.s_instance.InfoProvider.CurrentDifficulty.ToString(),
                 GameControlManager.s_instance.InfoProvider.Author,
-                GameControlManager.CurrentTrackStatic.Song.clip.length);
-            string songStart = JsonConvert.SerializeObject(stageSongStartEvent);
-            Send("SongStart", songStart);
+                GameControlManager.s_instance.InfoProvider.Beatmapper,
+                GameControlManager.CurrentTrackStatic.Song.clip.length,
+                GameControlManager.CurrentTrackStatic.TrackBPM
+            );
+
+            Send("SongStart", stageSongStartEvent);
         }
 
         class StageSongEndEvent
@@ -124,32 +171,64 @@ namespace SynthRidersWebsockets
                 GameControlManager.s_instance.InfoProvider.TotalBadNotes,
                 GameControlManager.s_instance.InfoProvider.TotalFailNotes,
                 score.MaxCombo);
-            string songEnd = JsonConvert.SerializeObject(stageSongEndEvent);
-            Send("SongEnd", songEnd);
+            Send("SongEnd", stageSongEndEvent);
         }
 
         class StageNoteHitEvent
         {
+            public int score { get; set; }
             public int combo { get; set; }
+            public int multiplier { get; set; }
             public float completed { get; set; }
-            public StageNoteHitEvent(int combo, float completed)
+            public float lifeBarPercent { get; set; }
+            
+            public StageNoteHitEvent(int score, int combo, float completed, int multiplier, float lifeBarPercent)
             {
+                this.score = score;
                 this.combo = combo;
                 this.completed = completed;
+                this.multiplier = multiplier;
+                this.lifeBarPercent = lifeBarPercent;
             }
         }
         private void OnNoteHit()
         {
             Game_ScoreManager score = (Game_ScoreManager) ReflectionUtils.GetValue(GameControlManager.s_instance, "m_scoreManager");
+            
             StageNoteHitEvent stageNoteHitEvent = new StageNoteHitEvent(
+                score.Score,
                 score.CurrentCombo,
-                score.NotesCompleted);
-            Send("NoteHit", JsonConvert.SerializeObject(stageNoteHitEvent));
+                score.NotesCompleted,
+                score.TotalMultiplier,
+                LifeBarHelper.GetScalePercent()
+            );
+            
+            Send("NoteHit", stageNoteHitEvent);
         }
+        class StageNoteMissEvent
+        {
+            public float playTimeMS;
 
+            public int multiplier;
+
+            public float lifeBarPercent;
+
+            public StageNoteMissEvent(float playTimeMS, int multiplier, float lifeBarPercent)
+            {
+                this.playTimeMS = playTimeMS;
+                this.multiplier = multiplier;
+                this.lifeBarPercent = lifeBarPercent;
+            }
+        }
         private void OnNoteFail()
         {
-            Send("NoteMiss", "{}");
+            StageNoteMissEvent missEvent = new StageNoteMissEvent(
+                GameControlManager.s_instance.PlayTimeMS, 
+                GameControlManager.s_instance.ScoreManager.TotalMultiplier,
+                LifeBarHelper.GetScalePercent()
+            );
+
+            Send("NoteMiss", missEvent);
         }
 
         private void OnEnterSpecial()
@@ -167,10 +246,25 @@ namespace SynthRidersWebsockets
             Send("FailSpecial", "{}");
         }
 
-        public void Send(string eventName, string data)
+        class OutputEvent
+        {
+            public string eventType;
+            public object data;
+
+            public OutputEvent(string eventType, object data)
+            {
+                this.eventType = eventType;
+                this.data = data;
+            }
+        }
+        public void Send(string eventName, object data)
         {
             if (Websocket.server == null) return;
-            Websocket.Send(eventName + " " + data);
+            OutputEvent outputEvent = new OutputEvent(eventName, data);
+
+            Websocket.Send(JsonConvert.SerializeObject(outputEvent));
+
+            MelonLogger.Msg(JsonConvert.SerializeObject(outputEvent));
         }
 
         public class Websocket


### PR DESCRIPTION
So I've made several changes here, please do feel free to offer feedback you may have.  

* To make parsing events easier for clients listening to events, I made the events completely JSON instead of the event name followed by a JSON string.   All clients need to do is parse the incoming message and all the data is available as an object.
* Added more properties to SongStart, NoteHit and NoteMiss, including data on score, health bar, song bpm, beatmapper, etc.
* Added a new event `PlayTime` that's emitted roughly once per second indicating the current song position as the song plays. 
* Updated the README.md with the new events and format, and a few hints on how to install the mod.
