### PR TITLE
Scene change, return to menu and album art

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,15 +52,38 @@ All events are JSON and follow this general structure:
 Emitted when the map begins playing.
 
 ```json
-{"eventType":"SongStart","data":{"song":"2 Phut Hon (Kaiz Remix)","difficulty":"Master","author":"Phao","beatMapper":"ICHDerHorst","length":191.857,"bpm":128.0}}
+{
+    "eventType":"SongStart",
+	"data":{
+     	"song":"2 Phut Hon (Kaiz Remix)",
+        "difficulty":"Master",
+        "author":"Phao",
+        "beatMapper":"ICHDerHorst",
+        "length":191.857,
+        "bpm":128.0,
+        "albumArt": ""
+	}
+}
 ```
+
+`albumArt` - If album art is available, this contains a data url containing a base64-encoded PNG image.  (You can use this URL as-is in a web browser or browser source to display the image).  Otherwise it's an empty string.
 
 ### SongEnd
 
 Emitted as the last note of the map is completed.
 
 ```json
-{"eventType":"SongEnd","data":{"song":"2 Phut Hon (Kaiz Remix)","perfect":350,"normal":126,"bad":281,"fail":2,"highestCombo":482}}
+{
+    "eventType":"SongEnd",
+    "data":{
+        "song":"2 Phut Hon (Kaiz Remix)",
+        "perfect":350,
+        "normal":126,
+        "bad":281,
+        "fail":2,
+        "highestCombo":482
+    }
+}
 ```
 
 ### PlayTime
@@ -78,7 +101,16 @@ Emitted once per second when the song is playing.
 Emitted on every note hit successfully
 
 ```json
-{"eventType":"NoteHit","data":{"score":938,"combo":1,"multiplier":1,"completed":1.0,"lifeBarPercent":1.0}}
+{
+    "eventType":"NoteHit",
+    "data":{
+        "score":938,
+        "combo":1,
+        "multiplier":1,
+        "completed":1.0,
+        "lifeBarPercent":1.0
+    }
+}
 ```
 
   - `score` - Total score after the note is hit
@@ -90,7 +122,13 @@ Emitted on every note hit successfully
 ### NoteMiss
 
 ```json
-{"eventType":"NoteMiss","data":{"multiplier":2,"lifeBarPercent":0.8333333}}
+{
+    "eventType":"NoteMiss",
+    "data":{
+        "multiplier":2,
+        "lifeBarPercent":0.8333333
+    }
+}
 ```
 
 ### EnterSpecial
@@ -110,3 +148,29 @@ Emitted on every note hit successfully
 ```json
 {"eventType":"FailSpecial","data":{}}
 ```
+
+### SceneChange
+
+Emitted when changing 'scenes'.  For example, changing to game play, summary, main menu, etc.  
+
+Some scene names of interest:
+
+* `3.GameEnd` - The summary scene after successfully completing a map where it shows your score, accuracy, etc.  
+
+```json
+{
+    "eventType":"SceneChange",
+    "data":{
+        "sceneName":"3.GameEnd"
+    }
+}
+```
+
+### ReturnToMenu
+
+Emitted when the user selects the "Return to Menu" button on the game pause screen.
+
+```
+{"eventType":"ReturnToMenu","data":{}}
+```
+

--- a/src/Harmony/RuntimePatch.cs
+++ b/src/Harmony/RuntimePatch.cs
@@ -44,3 +44,13 @@ public class GameControlManagerPatch
         SynthRidersWebsockets.WebsocketMod.Instance.GameManagerInit();
     }
 }
+
+[HarmonyPatch(typeof(GameControlManager), "ReturnToMenu")]
+public class GameControlManagerReturnToMenuPatch
+{
+    [HarmonyPostfix]
+    public static void PostFix()
+    {
+        SynthRidersWebsockets.WebsocketMod.Instance.EmitReturnToMenuEvent();
+    }
+}

--- a/src/WebsocketMod.cs
+++ b/src/WebsocketMod.cs
@@ -69,8 +69,6 @@ namespace SynthRidersWebsockets
         {
             base.OnSceneWasLoaded(buildIndex, sceneName);
 
-            LoggerInstance.Msg("SceneChange: " + sceneName);
-
             SceneChangeEvent sceneChangeEvent = new SceneChangeEvent(sceneName);
             
             this.Send("SceneChange", sceneChangeEvent);
@@ -104,7 +102,6 @@ namespace SynthRidersWebsockets
 
         public void EmitReturnToMenuEvent()
         {
-            MelonLogger.Msg("Emitting return to menu event");
             this.Send("ReturnToMenu", new object());
         }
 
@@ -161,8 +158,9 @@ namespace SynthRidersWebsockets
         }
         private void OnSongStart()
         {
-            // Find how I might get at the rendered png file for the album art.
-            // If I'm lucky, it'll be present by the time the song starts.
+            // It'd be better to get this directly from within the game, but it seems
+            // artwork isn't populated in the info provider.  This seems to work well enough
+            // but do feel free to implement a better option if available.
             string albumArtPath = Directory.GetCurrentDirectory() + "\\SongStatusImage.png";
             string albumArtEncoded = null;
 


### PR DESCRIPTION
* New event: SceneChange - emitted when changing scenes in the game (e.g. the main menu, in-game, game summary screen, etc).  
* New event: ReturnToMenu - emitted when the user selects the "Return to Menu" button on the pause screen
* Add album art to SongStart event
