### PR TITLE
playTimeMS added to NoteHit / NoteMiss, and client parsing added

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,3 +219,14 @@ Emitted when the user selects the "Return to Menu" button on the game pause scre
 }
 ```
 
+---
+
+## Using from another mod
+
+To easily consume these events from another Synth Riders mod:
+- Target .NET 4.8 to match this project
+- Add a Reference to SynthRidersWebsockets.dll
+- Implement the ISynthRidersEventHandler interface
+- Create a new `SynthRidersEventsManager` after `Awake()` is called (to make sure the socket is created before connecting)
+
+See [SRPerformanceMeter](https://github.com/bookdude13/SRPerformanceMeter) as an example implementation.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Connect to the websocket server; the server will send updates about the game.  B
 All events are JSON and follow this general structure:
 
 ```json
-{ "eventType": "EventType", "data": {}}
+{ "eventType": "EventType", "data": {} }
 ```
 
 ### SongStart 
@@ -53,20 +53,27 @@ Emitted when the map begins playing.
 
 ```json
 {
-    "eventType":"SongStart",
-	"data":{
-     	"song":"2 Phut Hon (Kaiz Remix)",
-        "difficulty":"Master",
-        "author":"Phao",
-        "beatMapper":"ICHDerHorst",
-        "length":191.857,
-        "bpm":128.0,
+    "eventType": "SongStart",
+	"data": {
+     	"song": "2 Phut Hon (Kaiz Remix)",
+        "difficulty": "Master",
+        "author": "Phao",
+        "beatMapper": "ICHDerHorst",
+        "length": 191.857,
+        "bpm": 128.0,
         "albumArt": ""
 	}
 }
 ```
 
-`albumArt` - If album art is available, this contains a data url containing a base64-encoded PNG image.  (You can use this URL as-is in a web browser or browser source to display the image).  Otherwise it's an empty string.
+- `song` - Song title
+- `difficulty` - Song difficulty
+- `author` - Song artist/author
+- `beatMapper` - Map creator
+- `length` - Song length in seconds
+- `bpm` - Song beats per minute
+- `albumArt` - If album art is available, this contains a data url containing a base64-encoded PNG image.  (You can use this URL as-is in a web browser or browser source to display the image).  Otherwise it's an empty string.
+
 
 ### SongEnd
 
@@ -74,27 +81,41 @@ Emitted as the last note of the map is completed.
 
 ```json
 {
-    "eventType":"SongEnd",
-    "data":{
-        "song":"2 Phut Hon (Kaiz Remix)",
-        "perfect":350,
-        "normal":126,
-        "bad":281,
-        "fail":2,
-        "highestCombo":482
+    "eventType": "SongEnd",
+    "data": {
+        "song": "2 Phut Hon (Kaiz Remix)",
+        "perfect": 350,
+        "normal": 126,
+        "bad": 281,
+        "fail": 2,
+        "highestCombo": 482
     }
 }
 ```
+
+- `song` - Song title
+- `perfect` - Number of perfect hits
+- `normal` - Number of normal hits
+- `bad` - Number of bad hits
+- `fail` - Number of failed hits
+- `highestCombo` - Highest number of consecutive hits during song
+
 
 ### PlayTime
 
 Emitted once per second when the song is playing.
 
 ```json
-{"eventType":"PlayTime","data":{"playTimeMS":19662.48}}
+{
+    "eventType": "PlayTime",
+    "data": {
+        "playTimeMS": 19662.48
+    }
+}
 ```
 
 - `playTimeMS` - Current play time position, in milliseconds.
+
 
 ### NoteHit
 
@@ -102,51 +123,69 @@ Emitted on every note hit successfully
 
 ```json
 {
-    "eventType":"NoteHit",
-    "data":{
-        "score":938,
-        "combo":1,
-        "multiplier":1,
-        "completed":1.0,
-        "lifeBarPercent":1.0
+    "eventType": "NoteHit",
+    "data": {
+        "score": 938,
+        "combo": 1,
+        "multiplier": 1,
+        "completed": 1.0,
+        "lifeBarPercent": 1.0,
+        "playTimeMS": 19662.48
     }
 }
 ```
 
-  - `score` - Total score after the note is hit
-  - `combo` - Number of consecutive hits made so far.  This resets after a note miss.
-  - `multiplier` - Current score multiplier.  Runs from 1 to 6.
-  - `completed` - Indicates the percentage of notes completed in the map.? (CHECK THIS)
-  - `lifeBarPercent` - A number between 0 and 1 indicating life bar percentage.
+- `score` - Total score after the note is hit
+- `combo` - Number of consecutive hits made so far. This resets after a note miss.
+- `multiplier` - Current score multiplier.  Runs from 1 to 6.
+- `completed` - Running total of all notes hit (perfect + normal + bad, no fails)
+- `lifeBarPercent` - A number between 0 and 1 indicating life bar percentage.
+- `playTimeMS` - Current play time position, in milliseconds.
+
 
 ### NoteMiss
 
 ```json
 {
-    "eventType":"NoteMiss",
-    "data":{
-        "multiplier":2,
-        "lifeBarPercent":0.8333333
+    "eventType": "NoteMiss",
+    "data": {
+        "multiplier": 2,
+        "lifeBarPercent": 0.8333333,
+        "playTimeMS": 19662.48
     }
 }
 ```
 
+- `multiplier` - Score multiplier before this miss resets it.
+- `lifeBarPercent` - A number between 0 and 1 indicating life bar percentage.
+- `playTimeMS` - Current play time position, in milliseconds.
+
+
 ### EnterSpecial
 
 ```json
-{"eventType":"EnterSpecial","data":{}}
+{
+    "eventType": "EnterSpecial",
+    "data": {}
+}
 ```
 
 ### CompleteSpecial
 
 ```json
-{"eventType":"CompleteSpecial","data":{}}
+{
+    "eventType":"CompleteSpecial",
+    "data": {}
+}
 ```
 
 ### FailSpecial
 
 ```json
-{"eventType":"FailSpecial","data":{}}
+{
+    "eventType": "FailSpecial",
+    "data": {}
+}
 ```
 
 ### SceneChange
@@ -159,18 +198,24 @@ Some scene names of interest:
 
 ```json
 {
-    "eventType":"SceneChange",
-    "data":{
-        "sceneName":"3.GameEnd"
+    "eventType": "SceneChange",
+    "data": {
+        "sceneName": "3.GameEnd"
     }
 }
 ```
+
+- `sceneName` - Name of scene being entered
+
 
 ### ReturnToMenu
 
 Emitted when the user selects the "Return to Menu" button on the game pause screen.
 
-```
-{"eventType":"ReturnToMenu","data":{}}
+```json
+{
+    "eventType": "ReturnToMenu",
+    "data": {}
+}
 ```
 

--- a/src/Events/EventDataNoteHit.cs
+++ b/src/Events/EventDataNoteHit.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SynthRidersWebsockets.Events
+{
+    public class EventDataNoteHit
+    {
+        public int score = 0; // score _after_ note hit
+        public int combo = 0;
+        public int multiplier = 1;
+        public float completed = 1.0f; // perfect + normal + bad (all notes hit except fails)
+        public float lifeBarPercent = 1.0f;
+        public float playTimeMS = 0.0f; // Current play time
+
+        public EventDataNoteHit(int score, int combo, float completed, int multiplier, float lifeBarPercent, float playTimeMS)
+        {
+            this.score = score;
+            this.combo = combo;
+            this.completed = completed;
+            this.multiplier = multiplier;
+            this.lifeBarPercent = lifeBarPercent;
+            this.playTimeMS = playTimeMS;
+        }
+    }
+}

--- a/src/Events/EventDataNoteMiss.cs
+++ b/src/Events/EventDataNoteMiss.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SynthRidersWebsockets.Events
+{
+    public class EventDataNoteMiss
+    {
+        public int multiplier = 1; // multiplier before miss reset
+        public float lifeBarPercent = 1.0f;
+        public float playTimeMS = 0.0f; // Current play time
+
+        public EventDataNoteMiss(int multiplier, float lifeBarPercent, float playTimeMS)
+        {
+            this.multiplier = multiplier;
+            this.lifeBarPercent = lifeBarPercent;
+            this.playTimeMS = playTimeMS;
+        }
+    }
+}

--- a/src/Events/EventDataPlayTime.cs
+++ b/src/Events/EventDataPlayTime.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SynthRidersWebsockets.Events
+{
+    public class EventDataPlayTime
+    {
+        public float playTimeMS = 0.0f;
+        public EventDataPlayTime(float playTimeMS)
+        {
+            this.playTimeMS = playTimeMS;
+        }
+    }
+}

--- a/src/Events/EventDataSceneChange.cs
+++ b/src/Events/EventDataSceneChange.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SynthRidersWebsockets.Events
+{
+    public class EventDataSceneChange
+    {
+        public string sceneName = "";
+
+        public EventDataSceneChange(string sceneName)
+        {
+            this.sceneName = sceneName;
+        }
+    }
+}

--- a/src/Events/EventDataSongEnd.cs
+++ b/src/Events/EventDataSongEnd.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SynthRidersWebsockets.Events
+{
+    public class EventDataSongEnd
+    {
+        public string song = "";
+        public int perfect = 0;
+        public int normal = 0;
+        public int bad = 0;
+        public int fail = 0;
+        public int highestCombo = 0;
+
+        public EventDataSongEnd(string song, int perfect, int normal, int bad, int fail, int highestCombo)
+        {
+            this.song = song;
+            this.perfect = perfect;
+            this.normal = normal;
+            this.bad = bad;
+            this.fail = fail;
+            this.highestCombo = highestCombo;
+        }
+    }
+}

--- a/src/Events/EventDataSongStart.cs
+++ b/src/Events/EventDataSongStart.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SynthRidersWebsockets.Events
+{
+    public class EventDataSongStart
+    {
+        public string song = "";
+        public string difficulty = "";
+        public string author = "";
+        public string beatMapper = "";
+        public float length = 0.0f;
+        public float bpm = 0.0f;
+        public string albumArt = "";
+
+        public EventDataSongStart(string song, string difficulty, string author, string beatMapper, float length, float bpm, string albumArt = null)
+        {
+            this.song = song;
+            this.difficulty = difficulty;
+            this.author = author;
+            this.beatMapper = beatMapper;
+            this.length = length;
+            this.bpm = bpm;
+            this.albumArt = albumArt;
+        }
+    }
+}

--- a/src/Events/ISynthRidersEventHandler.cs
+++ b/src/Events/ISynthRidersEventHandler.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SynthRidersWebsockets.Events
+{
+    public interface ISynthRidersEventHandler
+    {
+        void OnSongStart(EventDataSongStart data);
+        void OnSongEnd(EventDataSongEnd data);
+        void OnPlayTime(EventDataPlayTime data);
+        void OnNoteHit(EventDataNoteHit data);
+        void OnNoteMiss(EventDataNoteMiss data);
+        void OnSceneChange(EventDataSceneChange data);
+        void OnReturnToMenu();
+    }
+}

--- a/src/Events/SynthRidersEvent.cs
+++ b/src/Events/SynthRidersEvent.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft;
+
+namespace SynthRidersWebsockets.Events
+{
+    public class SynthRidersEvent<T>
+    {
+        public string eventType;
+        public T data;
+
+        public SynthRidersEvent(string eventType, T data)
+        {
+            this.eventType = eventType;
+            this.data = data;
+        }
+    }
+}

--- a/src/Events/SynthRidersEventsManager.cs
+++ b/src/Events/SynthRidersEventsManager.cs
@@ -1,0 +1,135 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using WebSocketSharp;
+using MelonLoader;
+using Newtonsoft.Json;
+
+namespace SynthRidersWebsockets.Events
+{
+    public class SynthRidersEventsManager
+    {
+        private readonly MelonLogger.Instance logger;
+        private readonly WebSocket socket;
+        private bool isConnected = false;
+        private ISynthRidersEventHandler eventHandler;
+
+        public SynthRidersEventsManager(MelonLogger.Instance logger, string connectionString, ISynthRidersEventHandler eventHandler)
+        {
+            this.logger = logger;
+            this.eventHandler = eventHandler;
+            
+            // Set up, but don't open yet
+            socket = new WebSocket(connectionString);
+            socket.OnOpen += (sender, e) => HandleOpen(sender);
+            socket.OnMessage += HandleMessage;
+            socket.OnError += HandleError;
+            socket.OnClose += HandleClose;
+        }
+
+        public void StartAsync()
+        {
+            try
+            {
+                if (isConnected)
+                {
+                    logger.Msg("Closing open websocket...");
+                    socket.Close();
+                }
+
+                logger.Msg("Connecting to websocket at " + socket.Url);
+                socket.ConnectAsync();
+            }
+            catch (Exception e)
+            {
+                logger.Msg("Failed to start websocket client! " + e.Message);
+            }
+        }
+
+        private void HandleOpen(object sender)
+        {
+            logger.Msg(string.Format(
+                "Opened websocket client with sender {0}",
+                sender
+            ));
+            isConnected = true;
+        }
+
+        private void HandleMessage(object sender, MessageEventArgs messageArgs)
+        {
+            try
+            {
+                // Parse top layer as generic to get type, then parse the specific message data if needed.
+                var genericEvent = JsonConvert.DeserializeObject<SynthRidersEvent<object>>(messageArgs.Data);
+                if (genericEvent.eventType == "SongStart")
+                {
+                    var songStart = JsonConvert.DeserializeObject<SynthRidersEvent<EventDataSongStart>>(messageArgs.Data);
+                    eventHandler.OnSongStart(songStart.data);
+                }
+                else if (genericEvent.eventType == "SongEnd")
+                {
+                    var songEnd = JsonConvert.DeserializeObject<SynthRidersEvent<EventDataSongEnd>>(messageArgs.Data);
+                    eventHandler.OnSongEnd(songEnd.data);
+                }
+                else if (genericEvent.eventType == "PlayTime")
+                {
+                    var playTime = JsonConvert.DeserializeObject<SynthRidersEvent<EventDataPlayTime>>(messageArgs.Data);
+                    eventHandler.OnPlayTime(playTime.data);
+                }
+                else if (genericEvent.eventType == "NoteHit")
+                {
+                    var noteHit = JsonConvert.DeserializeObject<SynthRidersEvent<EventDataNoteHit>>(messageArgs.Data);
+                    eventHandler.OnNoteHit(noteHit.data);
+                }
+                else if (genericEvent.eventType == "NoteMiss")
+                {
+                    var noteMiss = JsonConvert.DeserializeObject<SynthRidersEvent<EventDataNoteMiss>>(messageArgs.Data);
+                    eventHandler.OnNoteMiss(noteMiss.data);
+                }
+                else if (genericEvent.eventType == "SceneChange")
+                {
+                    var sceneChange = JsonConvert.DeserializeObject<SynthRidersEvent<EventDataSceneChange>>(messageArgs.Data);
+                    eventHandler.OnSceneChange(sceneChange.data);
+                }
+                else if (genericEvent.eventType == "ReturnToMenu")
+                {
+                    eventHandler.OnReturnToMenu();
+                }
+            }
+            catch (Exception e)
+            {
+                logger.Msg("Failed to parse message " + messageArgs.Data + ": " + e.Message);
+            }
+        }
+
+        private void HandleError(object sender, ErrorEventArgs errorArgs)
+        {
+            logger.Msg(string.Format(
+                "Error in websocket handling: {0}.\n{1}",
+                errorArgs.Message,
+                errorArgs.Exception
+            ));
+        }
+
+        private void HandleClose(object sender, CloseEventArgs closeArgs)
+        {
+            logger.Msg(string.Format(
+                "Closing websocket client with code {0} ({1})",
+                closeArgs.Code,
+                closeArgs.Reason
+            ));
+
+            isConnected = false;
+        }
+
+        public void Shutdown()
+        {
+            if (isConnected)
+            {
+                socket.Close();
+            }
+        }
+    }
+}

--- a/src/SynthRidersWebsockets.csproj
+++ b/src/SynthRidersWebsockets.csproj
@@ -63,6 +63,15 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Events\EventDataNoteHit.cs" />
+    <Compile Include="Events\EventDataNoteMiss.cs" />
+    <Compile Include="Events\EventDataPlayTime.cs" />
+    <Compile Include="Events\EventDataSceneChange.cs" />
+    <Compile Include="Events\EventDataSongEnd.cs" />
+    <Compile Include="Events\EventDataSongStart.cs" />
+    <Compile Include="Events\ISynthRidersEventHandler.cs" />
+    <Compile Include="Events\SynthRidersEvent.cs" />
+    <Compile Include="Events\SynthRidersEventsManager.cs" />
     <Compile Include="Harmony\RuntimePatch.cs" />
     <Compile Include="WebsocketMod.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/SynthRidersWebsockets.sln
+++ b/src/SynthRidersWebsockets.sln
@@ -1,9 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.1.32210.238
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.32228.343
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SynthRidersWebsockets", "SynthRidersWebsockets.csproj", "{D7E6917C-A708-4B3C-AA44-685765F620DE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SynthRidersWebsocketsTests", "..\tests\SynthRidersWebsocketsTests.csproj", "{F3C3F349-97D4-416A-AF7A-375BD17A2407}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +17,10 @@ Global
 		{D7E6917C-A708-4B3C-AA44-685765F620DE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D7E6917C-A708-4B3C-AA44-685765F620DE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D7E6917C-A708-4B3C-AA44-685765F620DE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F3C3F349-97D4-416A-AF7A-375BD17A2407}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F3C3F349-97D4-416A-AF7A-375BD17A2407}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F3C3F349-97D4-416A-AF7A-375BD17A2407}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F3C3F349-97D4-416A-AF7A-375BD17A2407}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/WebsocketMod.cs
+++ b/src/WebsocketMod.cs
@@ -19,14 +19,16 @@ using UnityEngine.Events;
 using MelonLoader;
 
 using SynthRidersWebsockets.Harmony;
+using SynthRidersWebsockets.Events;
+
 /*
- * Todo:
- * - Emit event if song failed.
- * - Emit event is song is quit.
- * - Previous high score
- * - Emit what hand note was for (left, right, special one-hand, special two-hand
- * - Score on specific hits
- */
+* Todo:
+* - Emit event if song failed.
+* - Emit event is song is quit.
+* - Previous high score
+* - Emit what hand note was for (left, right, special one-hand, special two-hand)
+* - Score on specific hits
+*/
 namespace SynthRidersWebsockets
 {
     public class WebsocketMod : MelonMod
@@ -57,32 +59,12 @@ namespace SynthRidersWebsockets
             Websocket.Stop();
         }
 
-        public class SceneChangeEvent
-        {
-            public string sceneName;
-
-            public SceneChangeEvent(string sceneName)
-            {
-                this.sceneName = sceneName;
-            }
-        }
         public override void OnSceneWasLoaded(int buildIndex, string sceneName)
         {
             base.OnSceneWasLoaded(buildIndex, sceneName);
 
-            SceneChangeEvent sceneChangeEvent = new SceneChangeEvent(sceneName);
-            
-            this.Send("SceneChange", sceneChangeEvent);
-        }
-
-        class PlayTimeEvent
-        {
-            public float playTimeMS;
-
-            public PlayTimeEvent(float playTimeMS)
-            {
-                this.playTimeMS = playTimeMS;
-            }
+            EventDataSceneChange sceneChangeEvent = new EventDataSceneChange(sceneName);
+            Send(new SynthRidersEvent<EventDataSceneChange>("SceneChange", sceneChangeEvent));
         }
 
         public override void OnUpdate()
@@ -95,8 +77,8 @@ namespace SynthRidersWebsockets
                     this.currentPlayTimeMS = gameControlManager.PlayTimeMS;
                     if (currentPlayTimeMS - lastPlayTimeEventMS > 999)
                     {
-                        PlayTimeEvent playTimeEvent = new PlayTimeEvent(currentPlayTimeMS);
-                        Send("PlayTime", playTimeEvent);
+                        EventDataPlayTime playTimeEvent = new EventDataPlayTime(currentPlayTimeMS);
+                        Send(new SynthRidersEvent<EventDataPlayTime>("PlayTime", playTimeEvent));
                         this.lastPlayTimeEventMS = currentPlayTimeMS;
                     }
                 }
@@ -109,7 +91,7 @@ namespace SynthRidersWebsockets
 
         public void EmitReturnToMenuEvent()
         {
-            this.Send("ReturnToMenu", new object());
+            Send(new SynthRidersEvent<object>("ReturnToMenu", new object()));
         }
 
         public void GameManagerInit()
@@ -141,28 +123,7 @@ namespace SynthRidersWebsockets
                 LoggerInstance.Msg(e.Message);
             }
         }
-
-        class StageSongStartEvent
-        {
-            public string song;
-            public string difficulty;
-            public string author;
-            public string beatMapper;
-            public float length;
-            public float bpm;
-            public string albumArt;
-
-            public StageSongStartEvent(string song, string difficulty, string author, string beatMapper, float length, float bpm, string albumArt = null)
-            {
-                this.song = song;
-                this.difficulty = difficulty;
-                this.author = author;
-                this.beatMapper = beatMapper;
-                this.length = length;
-                this.bpm = bpm;
-                this.albumArt = albumArt;
-            }
-        }
+        
         private void OnSongStart()
         {
             // It'd be better to get this directly from within the game, but it seems
@@ -176,7 +137,7 @@ namespace SynthRidersWebsockets
                 albumArtEncoded = "data:image/png;base64," + System.Convert.ToBase64String(File.ReadAllBytes(albumArtPath));
             }
 
-            StageSongStartEvent stageSongStartEvent = new StageSongStartEvent(
+            EventDataSongStart songStartEvent = new EventDataSongStart(
                 GameControlManager.s_instance.InfoProvider.TrackName,
                 GameControlManager.s_instance.InfoProvider.CurrentDifficulty.ToString(),
                 GameControlManager.s_instance.InfoProvider.Author,
@@ -186,64 +147,28 @@ namespace SynthRidersWebsockets
                 albumArtEncoded
             );
 
-            Send("SongStart", stageSongStartEvent);
+            Send(new SynthRidersEvent<object>("SongStart", songStartEvent));
         }
 
-        class StageSongEndEvent
-        {
-            public string song;
-            public int perfect;
-            public int normal;
-            public int bad;
-            public int fail;
-            public int highestCombo;
-            public StageSongEndEvent(string song, int perfect, int normal, int bad, int fail, int highestCombo)
-            {
-                this.song = song;
-                this.perfect = perfect;
-                this.normal = normal;
-                this.bad = bad;
-                this.fail = fail;
-                this.highestCombo = highestCombo;
-            }
-        }
         private void OnSongEnd()
         {
             Game_ScoreManager score = (Game_ScoreManager)ReflectionUtils.GetValue(GameControlManager.s_instance, "m_scoreManager");
-            StageSongEndEvent stageSongEndEvent = new StageSongEndEvent(
+            EventDataSongEnd songEndEvent = new EventDataSongEnd(
                 GameControlManager.s_instance.InfoProvider.TrackName,
                 GameControlManager.s_instance.InfoProvider.TotalPerfectNotes,
                 GameControlManager.s_instance.InfoProvider.TotalNormalNotes,
                 GameControlManager.s_instance.InfoProvider.TotalBadNotes,
                 GameControlManager.s_instance.InfoProvider.TotalFailNotes,
                 score.MaxCombo);
-            Send("SongEnd", stageSongEndEvent);
-        }
 
-        class StageNoteHitEvent
-        {
-            public int score { get; set; }
-            public int combo { get; set; }
-            public int multiplier { get; set; }
-            public float completed { get; set; }
-            public float lifeBarPercent { get; set; }
-            public float playTimeMS { get; set; }
-            
-            public StageNoteHitEvent(int score, int combo, float completed, int multiplier, float lifeBarPercent, float playTimeMS)
-            {
-                this.score = score;
-                this.combo = combo;
-                this.completed = completed;
-                this.multiplier = multiplier;
-                this.lifeBarPercent = lifeBarPercent;
-                this.playTimeMS = playTimeMS;
-            }
+            Send(new SynthRidersEvent<EventDataSongEnd>("SongEnd", songEndEvent));
         }
+        
         private void OnNoteHit()
         {
             Game_ScoreManager score = (Game_ScoreManager) ReflectionUtils.GetValue(GameControlManager.s_instance, "m_scoreManager");
             
-            StageNoteHitEvent stageNoteHitEvent = new StageNoteHitEvent(
+            EventDataNoteHit noteHitEvent = new EventDataNoteHit(
                 score.Score,
                 score.CurrentCombo,
                 score.NotesCompleted,
@@ -251,65 +176,42 @@ namespace SynthRidersWebsockets
                 LifeBarHelper.GetScalePercent(),
                 currentPlayTimeMS
             );
-            
-            Send("NoteHit", stageNoteHitEvent);
+
+            Send(new SynthRidersEvent<EventDataNoteHit>("NoteHit", noteHitEvent));
         }
-        class StageNoteMissEvent
-        {
-            public int multiplier;
-
-            public float lifeBarPercent;
-            public float playTimeMS;
-
-
-            public StageNoteMissEvent(int multiplier, float lifeBarPercent, float playTimeMS)
-            {
-                this.multiplier = multiplier;
-                this.lifeBarPercent = lifeBarPercent;
-                this.playTimeMS = playTimeMS;
-            }
-        }
+        
         private void OnNoteFail()
         {
-            StageNoteMissEvent missEvent = new StageNoteMissEvent(
+            EventDataNoteMiss noteMissEvent = new EventDataNoteMiss(
                 GameControlManager.s_instance.ScoreManager.TotalMultiplier,
                 LifeBarHelper.GetScalePercent(),
                 currentPlayTimeMS
             );
 
-            Send("NoteMiss", missEvent);
+            Send(new SynthRidersEvent<EventDataNoteMiss>("NoteMiss", noteMissEvent));
         }
 
         private void OnEnterSpecial()
         {
-            Send("EnterSpecial", new object());
+            Send(new SynthRidersEvent<object>("EnterSpecial", new object()));
         }
 
         private void OnCompleteSpecial()
         {
-            Send("CompleteSpecial", new object());
+            Send(new SynthRidersEvent<object>("CompleteSpecial", new object()));
         }
 
         private void OnFailSpecial()
         {
-            Send("FailSpecial", new object());
+            Send(new SynthRidersEvent<object>("FailSpecial", new object()));
         }
 
-        class OutputEvent
+        public void Send<T>(SynthRidersEvent<T> outputEvent)
         {
-            public string eventType;
-            public object data;
-
-            public OutputEvent(string eventType, object data)
+            if (Websocket.server == null)
             {
-                this.eventType = eventType;
-                this.data = data;
+                return;
             }
-        }
-        public void Send(string eventName, object data)
-        {
-            if (Websocket.server == null) return;
-            OutputEvent outputEvent = new OutputEvent(eventName, data);
 
             Websocket.Send(JsonConvert.SerializeObject(outputEvent));
         }

--- a/tests/Properties/AssemblyInfo.cs
+++ b/tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,20 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("SynthRidersWebsocketsTests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("SynthRidersWebsocketsTests")]
+[assembly: AssemblyCopyright("Copyright ©  2022")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+
+[assembly: Guid("f3c3f349-97d4-416a-af7a-375bd17a2407")]
+
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/tests/SynthRidersWebsocketsTests.csproj
+++ b/tests/SynthRidersWebsocketsTests.csproj
@@ -1,0 +1,80 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\src\packages\MSTest.TestAdapter.2.2.8\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\src\packages\MSTest.TestAdapter.2.2.8\build\net45\MSTest.TestAdapter.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{F3C3F349-97D4-416A-AF7A-375BD17A2407}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>SynthRidersWebsocketsTests</RootNamespace>
+    <AssemblyName>SynthRidersWebsocketsTests</AssemblyName>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\src\packages\MSTest.TestFramework.2.2.8\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\src\packages\MSTest.TestFramework.2.2.8\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\src\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestMessageDeserialization.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\src\SynthRidersWebsockets.csproj">
+      <Project>{d7e6917c-a708-4b3c-aa44-685765f620de}</Project>
+      <Name>SynthRidersWebsockets</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\src\packages\MSTest.TestAdapter.2.2.8\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\src\packages\MSTest.TestAdapter.2.2.8\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\src\packages\MSTest.TestAdapter.2.2.8\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\src\packages\MSTest.TestAdapter.2.2.8\build\net45\MSTest.TestAdapter.targets'))" />
+  </Target>
+  <Import Project="..\src\packages\MSTest.TestAdapter.2.2.8\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\src\packages\MSTest.TestAdapter.2.2.8\build\net45\MSTest.TestAdapter.targets')" />
+</Project>

--- a/tests/TestMessageDeserialization.cs
+++ b/tests/TestMessageDeserialization.cs
@@ -1,0 +1,174 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using SynthRidersWebsockets.Events;
+
+namespace SynthRidersWebsocketsTests
+{
+    [TestClass]
+    public class TestMessageDeserialization
+    {
+        [TestMethod]
+        public void TestDeserializeTopLevel()
+        {
+            string message = @"
+            {
+                'eventType': 'EventType',
+                'data': {}
+            }";
+
+            var parsedEvent = JsonConvert.DeserializeObject<SynthRidersEvent<object>>(message);
+
+            Assert.AreEqual("EventType", parsedEvent.eventType);
+            Assert.IsNotNull(parsedEvent.data);
+        }
+
+        [TestMethod]
+        public void TestDeserializeSongStart()
+        {
+            string message = @"
+            {
+                'eventType': 'SongStart',
+                'data': {
+                    'song': 'ANIMA',
+                    'difficulty': 'Master',
+                    'author': 'ReoNa',
+                    'beatMapper': 'bookdude13',
+                    'length': 269.19,
+                    'bpm': 192.7,
+                    'albumArt': ''
+                }
+            }";
+
+            var parsedEvent = JsonConvert.DeserializeObject<SynthRidersEvent<EventDataSongStart>>(message);
+
+            Assert.AreEqual("SongStart", parsedEvent.eventType);
+            Assert.IsNotNull(parsedEvent.data);
+            Assert.AreEqual("ANIMA", parsedEvent.data.song);
+            Assert.AreEqual("Master", parsedEvent.data.difficulty);
+            Assert.AreEqual("ReoNa", parsedEvent.data.author);
+            Assert.AreEqual("bookdude13", parsedEvent.data.beatMapper);
+            Assert.AreEqual(269.19, parsedEvent.data.length, 0.00001);
+            Assert.AreEqual(192.7, parsedEvent.data.bpm, 0.00001);
+            Assert.AreEqual("", parsedEvent.data.albumArt);
+        }
+
+        [TestMethod]
+        public void TestDeserializeSongEnd()
+        {
+            string message = @"
+            {
+                'eventType': 'SongEnd',
+                'data': {
+                    'song': 'ANIMA',
+                    'perfect': 12,
+                    'normal': 3,
+                    'bad': 4,
+                    'fail': 1,
+                    'highestCombo': 11
+                }
+            }";
+
+            var parsedEvent = JsonConvert.DeserializeObject<SynthRidersEvent<EventDataSongEnd>>(message);
+
+            Assert.AreEqual("SongEnd", parsedEvent.eventType);
+            Assert.IsNotNull(parsedEvent.data);
+            Assert.AreEqual("ANIMA", parsedEvent.data.song);
+            Assert.AreEqual(12, parsedEvent.data.perfect);
+            Assert.AreEqual(3, parsedEvent.data.normal);
+            Assert.AreEqual(4, parsedEvent.data.bad);
+            Assert.AreEqual(1, parsedEvent.data.fail);
+            Assert.AreEqual(11, parsedEvent.data.highestCombo);
+        }
+
+        [TestMethod]
+        public void TestDeserializePlayTime()
+        {
+            string message = @"
+            {
+                'eventType': 'PlayTime',
+                'data': {
+                    'playTimeMS': 12345.67
+                }
+            }";
+
+            var parsedEvent = JsonConvert.DeserializeObject<SynthRidersEvent<EventDataPlayTime>>(message);
+
+            Assert.AreEqual("PlayTime", parsedEvent.eventType);
+            Assert.IsNotNull(parsedEvent.data);
+            Assert.AreEqual(12345.67, parsedEvent.data.playTimeMS, 0.0001);
+        }
+
+        [TestMethod]
+        public void TestDeserializeNoteHit()
+        {
+            string message = @"
+            {
+                'eventType': 'NoteHit',
+                'data': {
+                    'score': 12300,
+                    'combo': 312,
+                    'multiplier': 3,
+                    'completed': 1.0,
+                    'lifeBarPercent': 0.83333,
+                    'playTimeMS': 1234.56
+                }
+            }";
+
+            var parsedEvent = JsonConvert.DeserializeObject<SynthRidersEvent<EventDataNoteHit>>(message);
+
+            Assert.AreEqual("NoteHit", parsedEvent.eventType);
+            Assert.IsNotNull(parsedEvent.data);
+            Assert.AreEqual(12300, parsedEvent.data.score);
+            Assert.AreEqual(312, parsedEvent.data.combo);
+            Assert.AreEqual(3, parsedEvent.data.multiplier);
+            Assert.AreEqual(1.0, parsedEvent.data.completed, 0.00001);
+            Assert.AreEqual(0.83333, parsedEvent.data.lifeBarPercent, 0.00001);
+            Assert.AreEqual(1234.56, parsedEvent.data.playTimeMS, 0.0001);
+        }
+
+        [TestMethod]
+        public void TestDeserializeNoteMiss()
+        {
+            string message = @"
+            {
+                'eventType': 'NoteMiss',
+                'data': {
+                    'multiplier': 3,
+                    'lifeBarPercent': 0.83333,
+                    'playTimeMS': 1234.56
+                }
+            }";
+
+            var parsedEvent = JsonConvert.DeserializeObject<SynthRidersEvent<EventDataNoteMiss>>(message);
+
+            Assert.AreEqual("NoteMiss", parsedEvent.eventType);
+            Assert.IsNotNull(parsedEvent.data);
+            Assert.AreEqual(3, parsedEvent.data.multiplier);
+            Assert.AreEqual(0.83333, parsedEvent.data.lifeBarPercent, 0.00001);
+            Assert.AreEqual(1234.56, parsedEvent.data.playTimeMS, 0.0001);
+        }
+
+        [TestMethod]
+        public void TestDeserializeSceneChange()
+        {
+            string message = @"
+            {
+                'eventType': 'SceneChange',
+                'data': {
+                    'sceneName': '3.GameEnd'
+                }
+            }";
+
+            var parsedEvent = JsonConvert.DeserializeObject<SynthRidersEvent<EventDataSceneChange>>(message);
+
+            Assert.AreEqual("SceneChange", parsedEvent.eventType);
+            Assert.IsNotNull(parsedEvent.data);
+            Assert.AreEqual("3.GameEnd", parsedEvent.data.sceneName);
+        }
+    }
+}

--- a/tests/packages.config
+++ b/tests/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="MSTest.TestAdapter" version="2.2.8" targetFramework="net48" />
+  <package id="MSTest.TestFramework" version="2.2.8" targetFramework="net48" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net48" />
+</packages>


### PR DESCRIPTION
I added playTimeMS to the NoteHit and NoteMiss events so I could use those in SRPerformanceMeter.

While implementing/parsing the messages, I realized the code I was writing could be used by other mods, so I added it in this PR as well. If you'd rather it stays separate I can do that. README explains how it can be implemented. Tested with SRPerformanceMeter and I get all data coming through, no noticeable performance issues.